### PR TITLE
feat: add a boardStorage object - resolves #21

### DIFF
--- a/nerdlets/nr1-cards-for-observability-nerdlet/index.js
+++ b/nerdlets/nr1-cards-for-observability-nerdlet/index.js
@@ -183,13 +183,22 @@ export default class CardsForObservability extends React.Component {
     );
     window.boardStorage = {
       data: {},
-      get items() { return this.data; },
+      get items() {
+        return this.data;
+      },
       getItem(id) {
+        // eslint-disable-next-line no-prototype-builtins
         return this.data.hasOwnProperty(id) ? this.data[id] : undefined;
       },
-      setItem(id, value) { this.data[id] = value; },
-      removeItem(id) { delete this.data[id]; },
-      clear() { this.data = {}; }
+      setItem(id, value) {
+        this.data[id] = value;
+      },
+      removeItem(id) {
+        delete this.data[id];
+      },
+      clear() {
+        this.data = {};
+      }
     };
   };
 
@@ -209,6 +218,7 @@ export default class CardsForObservability extends React.Component {
   closeDashboard = () => {
     document.dispatchEvent(new CustomEvent('dashboardclosed'));
     this.fetchTimeout();
+    if ('boardStorage' in window) window.boardStorage.clear();
     nerdlet.setUrlState({ dashboard: null });
     const { current } = this.state;
     current.auth = false;
@@ -304,7 +314,7 @@ export default class CardsForObservability extends React.Component {
 
     const store = 'boardStorage' in window ? window.boardStorage.items : {};
 
-    const cardData = {...data, ...store};
+    const cardData = { ...data, ...store };
 
     const picker = showPicker ? (
       <div className="container">

--- a/nerdlets/nr1-cards-for-observability-nerdlet/index.js
+++ b/nerdlets/nr1-cards-for-observability-nerdlet/index.js
@@ -159,6 +159,7 @@ export default class CardsForObservability extends React.Component {
 
     if (!firstFetch) {
       addScripts(scripts);
+      if ('boardStorage' in window) window.boardStorage.clear();
       this.setState({ firstFetch: true });
     }
     document.dispatchEvent(new CustomEvent('datarefreshed', { detail: data }));
@@ -180,6 +181,16 @@ export default class CardsForObservability extends React.Component {
     this.setState({ current, showPicker: !dashboard }, () =>
       dashboard ? this.loadDashboard(dashboard) : null
     );
+    window.boardStorage = {
+      data: {},
+      get items() { return this.data; },
+      getItem(id) {
+        return this.data.hasOwnProperty(id) ? this.data[id] : undefined;
+      },
+      setItem(id, value) { this.data[id] = value; },
+      removeItem(id) { delete this.data[id]; },
+      clear() { this.data = {}; }
+    };
   };
 
   markAuth = () => {
@@ -291,6 +302,10 @@ export default class CardsForObservability extends React.Component {
       showPicker
     } = this.state;
 
+    const store = 'boardStorage' in window ? window.boardStorage.items : {};
+
+    const cardData = {...data, ...store};
+
     const picker = showPicker ? (
       <div className="container">
         <Modal style={{ width: '90%', height: '90%' }} noClose>
@@ -304,13 +319,13 @@ export default class CardsForObservability extends React.Component {
     return dashboard ? (
       <div className={`container ${dashboard.layout || ''}`}>
         {cards &&
-          data &&
-          Object.keys(data).length > 0 &&
+          cardData &&
+          Object.keys(cardData).length > 0 &&
           cards.map((card, c) => (
             <Card
               key={c}
               card={card}
-              data={data}
+              data={cardData}
               layout={dashboard.layout || 'fluid'}
               index={c}
             />


### PR DESCRIPTION
- add a `boardStorage` object to `window` allowing state to be stored in dashboards
- clear out all existing items and reset `boardStorage` when a dashboard loads
- pass `boardStorage` to cards